### PR TITLE
Use connection instead of handle.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSMolgenisArmadillo
 Type: Package
-Version: 2.0.0
+Version: 2.0.1
 Title: 'DataSHIELD' Client for 'MOLGENIS Armadillo'
 Description: 'DataSHIELD' is an infrastructure and series of R packages that 
     enables the remote and 'non-disclosive' analysis of sensitive research data.

--- a/R/ArmadilloConnection.R
+++ b/R/ArmadilloConnection.R
@@ -66,7 +66,7 @@ methods::setMethod(
       handle = conn@handle,
       path = "/profiles",
       config = httr::add_headers(.get_auth_header(conn))
-      )
+    )
     .handle_request_error(response)
     if (response$status_code == 404) {
       # endpoint not implemented, fake it!
@@ -95,7 +95,7 @@ methods::setMethod(
       handle = conn@handle,
       path = "/tables",
       config = httr::add_headers(.get_auth_header(conn))
-      )
+    )
     .handle_request_error(response)
     .unlist_character_list(httr::content(response))
   }
@@ -143,7 +143,7 @@ methods::setMethod(
       handle = conn@handle,
       path = "/resources",
       config = httr::add_headers(.get_auth_header(conn))
-      )
+    )
     .handle_request_error(response)
     .unlist_character_list(httr::content(response))
   }
@@ -220,7 +220,7 @@ methods::setMethod(
       handle = conn@handle,
       path = "/symbols",
       config = httr::add_headers(.get_auth_header(conn))
-      )
+    )
     .handle_request_error(response)
     .unlist_character_list(httr::content(response))
   }
@@ -606,7 +606,7 @@ methods::setMethod(
       handle = conn@handle,
       path = "/actuator/info",
       config = httr::add_headers(.get_auth_header(conn))
-      ), silent = TRUE)
+    ), silent = TRUE)
     invisible(NULL)
   }
 )

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,8 +9,12 @@
 #' @return error message only
 #'
 #' @noRd
-.handle_last_command_error <- function(handle) {
-  command <- httr::GET(handle = handle, path = "/lastcommand")
+.handle_last_command_error <- function(conn) {
+  command <- httr::GET(
+    handle = conn@handle,
+    path = "/lastcommand",
+    config = httr::add_headers(.get_auth_header(conn))
+  )
 
   json_content <- httr::content(command)
   if (json_content$status == "FAILED") {
@@ -79,7 +83,7 @@
   .handle_request_error(response)
 
   if (response$status_code == 404) {
-    .handle_last_command_error(conn@handle)
+    .handle_last_command_error(conn)
   } else {
     content <- httr::content(response)
     if (is.null(content)) {

--- a/tests/testthat/test-ArmadilloConnection.R
+++ b/tests/testthat/test-ArmadilloConnection.R
@@ -26,8 +26,8 @@ test_that("dsDisconnect saves the workspace", {
 
 test_that("dsListProfiles retrieves profiles", {
   profiles <- list(
-    available = list("default", "exposome"),
-    current = "exposome")
+                   available = list("default", "exposome"),
+                   current = "exposome")
   get <- mock(list(status_code = 200))
   content <- mock(profiles)
   result <- with_mock(

--- a/tests/testthat/test-ArmadilloDriver.R
+++ b/tests/testthat/test-ArmadilloDriver.R
@@ -48,11 +48,11 @@ test_that("dsConnect selects profile if one is provided", {
   httr_handle <- mock(handle)
   with_mock(
     result <- dsConnect(driver,
-                        url = "https://example.org",
-                        username = "admin",
-                        password = "admin",
-                        profile = "foo",
-                        name = "test"
+      url = "https://example.org",
+      username = "admin",
+      password = "admin",
+      profile = "foo",
+      name = "test"
     ),
     "httr::POST" = httr_post,
     "httr::cookies" = httr_cookies,
@@ -65,11 +65,10 @@ test_that("dsConnect selects profile if one is provided", {
 
   expect_args(httr_handle, 1, url = "https://example.org")
   expect_args(httr_post, 1,
-              handle = handle,
-              path = "/select-profile",
-              body = "foo",
-              config =
-                httr::add_headers("Authorization" = "Basic YWRtaW46YWRtaW4=")
+    handle = handle,
+    path = "/select-profile",
+    body = "foo",
+    config = httr::add_headers("Authorization" = "Basic YWRtaW46YWRtaW4=")
   )
 })
 
@@ -80,10 +79,10 @@ test_that("dsConnect returns an ArmadilloConnection", {
   httr_handle <- mock(handle)
   with_mock(
     result <- dsConnect(driver,
-                        url = "https://example.org",
-                        username = "admin",
-                        password = "admin",
-                        name = "test"
+      url = "https://example.org",
+      username = "admin",
+      password = "admin",
+      name = "test"
     ),
     "httr::POST" = httr_post,
     "httr::cookies" = httr_cookies,
@@ -96,11 +95,10 @@ test_that("dsConnect returns an ArmadilloConnection", {
 
   expect_args(httr_handle, 1, url = "https://example.org")
   expect_args(httr_post, 1,
-              handle = handle,
-              path = "/select-profile",
-              body = "default",
-              config =
-                httr::add_headers("Authorization" = "Basic YWRtaW46YWRtaW4=")
+    handle = handle,
+    path = "/select-profile",
+    body = "default",
+    config = httr::add_headers("Authorization" = "Basic YWRtaW46YWRtaW4=")
   )
 })
 

--- a/tests/testthat/test-ArmadilloResult.R
+++ b/tests/testthat/test-ArmadilloResult.R
@@ -88,8 +88,8 @@ test_that("dsIsCompleted retrieves status of COMPLETED async command", {
 
 test_that("dsIsCompleted retrieves status of FAILED async command", {
   result <- methods::new("ArmadilloResult",
-                         conn = connection,
-                         rval = list(result = NULL, async = TRUE)
+    conn = connection,
+    rval = list(result = NULL, async = TRUE)
   )
 
   content <- mock(list(status = "FAILED"))
@@ -103,9 +103,9 @@ test_that("dsIsCompleted retrieves status of FAILED async command", {
 
   expect_equal(value, TRUE)
   expect_args(get, 1,
-              handle = connection@handle,
-              path = "/lastcommand",
-              config = httr::add_headers("Authorization" = "Bearer token")
+    handle = connection@handle,
+    path = "/lastcommand",
+    config = httr::add_headers("Authorization" = "Bearer token")
   )
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,34 +1,36 @@
 test_that(".handle_last_command_error throws error message", {
-  handle <- mock()
   ok <- list(status_code = 200)
   get <- mock(ok)
   content <- mock(list(status = "FAILED", message = "Error"))
+  setClass("connection", slots=list(handle="character", token="character"))
+  connection <- new("connection", handle="test", token="token")
 
   expect_error(
     with_mock(
-      .handle_last_command_error(handle),
+      .handle_last_command_error(connection),
       "httr::GET" = get,
       "httr::content" = content
     ), "Error"
   )
 
-  expect_args(get, 1, handle = handle, path = "/lastcommand")
+  expect_args(get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
   expect_args(content, 1, ok)
 })
 
 test_that(".handle_last_command_error only works if status is FAILED", {
-  handle <- mock()
+  setClass("connection", slots=list(handle="character", token="character"))
+  connection <- new("connection", handle="test", token="token")
   ok <- list(status_code = 200)
   get <- mock(ok)
   content <- mock(list(status = "COMPLETED"))
 
   with_mock(
-    .handle_last_command_error(handle),
+    .handle_last_command_error(connection),
     "httr::GET" = get,
     "httr::content" = content
   )
 
-  expect_args(get, 1, handle = handle, path = "/lastcommand")
+  expect_args(get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
 })
 
 test_that(".handle_request_error handles 401", {
@@ -95,6 +97,6 @@ test_that(".retry_until_last_result handles 404 by retrieving lastcommand", {
     ), "Execution failed: Error"
   )
 
-  expect_args(httr_get, 1, handle = handle, path = "/lastcommand")
+  expect_args(httr_get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
   expect_args(httr_content, 1, ok)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,8 +2,9 @@ test_that(".handle_last_command_error throws error message", {
   ok <- list(status_code = 200)
   get <- mock(ok)
   content <- mock(list(status = "FAILED", message = "Error"))
-  setClass("connection", slots=list(handle="character", token="character"))
-  connection <- new("connection", handle="test", token="token")
+  setClass("connection", slots = list(handle = "character",
+                                      token = "character"))
+  connection <- new("connection", handle = "test", token = "token")
 
   expect_error(
     with_mock(
@@ -12,14 +13,17 @@ test_that(".handle_last_command_error throws error message", {
       "httr::content" = content
     ), "Error"
   )
-
-  expect_args(get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
+  expect_args(get, 1, handle = connection@handle, path = "/lastcommand",
+              config = httr::add_headers(c("Authorization" =
+                                             paste0("Bearer ",
+                                                    connection@token))))
   expect_args(content, 1, ok)
 })
 
 test_that(".handle_last_command_error only works if status is FAILED", {
-  setClass("connection", slots=list(handle="character", token="character"))
-  connection <- new("connection", handle="test", token="token")
+  setClass("connection", slots = list(handle = "character",
+                                      token = "character"))
+  connection <- new("connection", handle = "test", token = "token")
   ok <- list(status_code = 200)
   get <- mock(ok)
   content <- mock(list(status = "COMPLETED"))
@@ -30,7 +34,10 @@ test_that(".handle_last_command_error only works if status is FAILED", {
     "httr::content" = content
   )
 
-  expect_args(get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
+  expect_args(get, 1, handle = connection@handle, path = "/lastcommand",
+              config = httr::add_headers(c("Authorization" =
+                                             paste0("Bearer ",
+                                                    connection@token))))
 })
 
 test_that(".handle_request_error handles 401", {
@@ -97,6 +104,9 @@ test_that(".retry_until_last_result handles 404 by retrieving lastcommand", {
     ), "Execution failed: Error"
   )
 
-  expect_args(httr_get, 1, handle = connection@handle, path = "/lastcommand", config = httr::add_headers(c("Authorization" = paste0("Bearer ", connection@token))))
+  expect_args(httr_get, 1, handle = connection@handle, path = "/lastcommand",
+              config = httr::add_headers(c("Authorization" =
+                                             paste0("Bearer ",
+                                                    connection@token))))
   expect_args(httr_content, 1, ok)
 })


### PR DESCRIPTION
## Blocks

- https://github.com/molgenis/molgenis-service-armadillo/pull/277

## Tests

- [x] Tests needs to be rewritten to use connection instead of handle.

We tested this against armadillo master and pr-277 using our small testscript switching between the two version

```R
#!/usr/bin/env Rscript
library(devtools)
#devtools::load_all()

library(cli)
library(DSI)
library(dsBaseClient)

# =========== toggle between these two version =====================
library(DSMolgenisArmadillo)
#devtools::install("/.../GitHub/molgenis-r-datashield/")

readRenviron("dev.env")

armadillo_url <- "http://localhost:8080/"
#armadillo_url <- "https://alspac-armadillo.molgenis.org"

token = Sys.getenv("TOKEN")
# comment next line if having a valid token in dev.env
token <- ""

if ( token == "") {
    cli_alert_warning("Fetching token ... requires pressing enter in browser")

    token <- armadillo.get_token(armadillo_url)

    cat("TOKEN\n")
    cat( token)
    cat("\n")
}

cat("Login into Armadillo\n")

builder <- DSI::newDSLoginBuilder()
builder$append(server = "armadillo",
               url = armadillo_url,
               profile="xenon",
               token = token,
               driver = "ArmadilloDriver")

cat("Building ...\n")
logindata <- builder$build()

cat("Connecting ...")
conns <- datashield.login(logins = logindata)

cat("Doing business ...\n")
# tot hier werkt het, de volgende gaat fout:
tryCatch({
    datashield.assign.table(conns, "lifecycle_monthlyrep", "lifecycle/core/monthlyrep", async = FALSE)
  },
  error = function(e) {
    #recover()
    cat("\n\nERROR\n")
    cat(paste0(datashield.errors()))
  }
)

cat("\n\nFinished\n")
```