### PR TITLE
fix: return correct error message when workspace doesn't exist

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -53,8 +53,8 @@
   } else if (response$status_code == 401) {
     stop("Unauthorized", call. = FALSE)
   } else if (response$status_code == 500) {
-    json_content <- httr::content(response)
-    stop(paste0("Internal server error: ", json_content$message), call. = FALSE)
+    json_content <- httr::content(response, "text")
+    stop(paste0("Internal server error: ", json_content), call. = FALSE)
   }
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -65,11 +65,11 @@ test_that(".handle_request_error handles 400", {
 
 test_that(".handle_request_error handles 500", {
   response <- list(status_code = 500)
-  httr_content <- mock(list(message = "Error"))
+  httr_content <- mock(message = "Something went wrong while reading/writing in the storage")
   with_mock(
     expect_error(
       .handle_request_error(response),
-      "Internal server error: Error"
+      "Internal server error: Something went wrong while reading/writing in the storage",
     ),
     "httr::content" = httr_content
   )


### PR DESCRIPTION
## To test
Specify URL, either using Armadillo running locally
`url <- "http://localhost:8080/"`

or use the demo server
`url <- "https://armadillo-demo.molgenis.net/"`

Get token and build login object:
```
token <- armadillo.get_token(url)

builder <- newDSLoginBuilder()
builder$append(
  url = url,
  server = "armadillo",
  token = token,
  table = "project-1/data/nonrep",
  driver = "ArmadilloDriver")

logindata <- builder$build()

```
Try to log in to a workspace that doesn't exist:
`conns <- DSI::datashield.login(logins = logindata, restore = "workspace_does_not_exist")`

Check that the following error message is received: 
`Error: Internal server error: Something went wrong while reading/writing in the storage`

In addition:
Run `devtools::check()`