### PR TITLE
chore: calling auth functions from namespace makes it hard to test 

### DIFF
--- a/R/ArmadilloOAuth.R
+++ b/R/ArmadilloOAuth.R
@@ -56,7 +56,7 @@ setClass(
 #' @export
 armadillo.get_credentials <- function(server) { # nolint
   auth_info <- .get_oauth_info(server)$auth
-  endpoint <- MolgenisAuth::discover(auth_info$issuerUri)
+  endpoint <- discover(auth_info$issuerUri)
   credentials <- device_flow_auth(
     endpoint,
     auth_info$clientId


### PR DESCRIPTION
## Background
Calling the `discover` using `MolgenisAuth::discover` makes it then quite hard to test the auth package, as it forces using the version installed, rather than the version being tested locally. It is also not best R practice - instead it should be declared via the imports.

## How to test
- [ ] Check CI green