### PR TITLE
feat!: major release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
     - run:
         name: Install R deps takes 15min, but no worries we skipinstalled from cache when this PR has installed them before
         command: |
-          Rscript -e 'install.packages(c("devtools", "pkgdown", "markdown", "rmarkdown", "mockery", "webmockr", "httr", "urltools", "xml2", "arrow", "MolgenisAuth", "DSI", "git2r", "ellipsis", "vctrs", "covr", "desc", "metafor", "fields", "meta", "gridExtra", "panelaggregation"))'
+          install2.r MolgenisAuth
+          install2.r --skipinstalled devtools pkgdown markdown rmarkdown mockery webmockr httr urltools xml2 arrow DSI git2r ellipsis vctrs covr desc metafor fields meta gridExtra
           Rscript -e 'install.packages("dsBaseClient", repos = "https://cran.obiba.org/")'
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
     - run:
         name: Install R deps takes 15min, but no worries we skipinstalled from cache when this PR has installed them before
         command: |
-          install2.r MolgenisAuth
-          install2.r --skipinstalled devtools pkgdown markdown rmarkdown mockery webmockr httr urltools xml2 arrow DSI git2r ellipsis vctrs covr desc metafor fields meta gridExtra
+          install2.r --repos=https://cloud.r-project.org MolgenisAuth
+          install2.r --repos=https://cloud.r-project.org --skipinstalled devtools pkgdown markdown rmarkdown mockery webmockr httr urltools xml2 arrow DSI git2r ellipsis vctrs covr desc metafor fields meta gridExtra
           Rscript -e 'install.packages("dsBaseClient", repos = "https://cran.obiba.org/")'
 
     - run:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,9 +43,10 @@ Imports:
     stringr,
     utils,
     base64enc,
-    urltools, 
-    dplyr, 
-    jsonlite
+    urltools,
+    dplyr,
+    jsonlite,
+    lifecycle
 Suggests:
     dsBaseClient (>= 6.0),
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Maintainer: Mariska Slofstra <m.k.slofstra@umcg.nl>
 Depends: 
     R (>= 3.6),
     DSI (>= 1.3.0),
-    MolgenisAuth (>= 0.0.25),
+    MolgenisAuth (>= 1.1.0),
 Imports: 
     methods,
     httr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Maintainer: Mariska Slofstra <m.k.slofstra@umcg.nl>
 Depends: 
     R (>= 3.6),
     DSI (>= 1.3.0),
-    MolgenisAuth (>= 1.1.0),
+    MolgenisAuth (>= 1.0.0),
 Imports: 
     methods,
     httr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# DSMolgenisArmadillo 3.0.0
+* Feat: Implemented functionality to refresh tokens if they have expired. This involved adding a 
+new function `armadillo.get_credentials` which replaces `armadillo.get_token`, and also retrieves
+a refresh token which is needed for the refresh. Functionality is added which works in the background
+to check if the token has expired, and if so refresh it.
+
 # DSMolgenisArmadillo 2.0.3
 
 # DSMolgenisArmadillo 2.0.2

--- a/R/ArmadilloOAuth.R
+++ b/R/ArmadilloOAuth.R
@@ -54,6 +54,21 @@ setClass(
 #' @return The credentials
 #' @importFrom MolgenisAuth discover device_flow_auth
 #' @importFrom methods new
+#' @examples
+#' \dontrun{
+#' example_url <- "https://armadillo.example.org"
+#' credentials <- armadillo.get_credentials(example_url)
+#'
+#' builder <- newDSLoginBuilder()
+#' builder$append(
+#'   url = example_url,
+#'   server = "example_server",
+#'   token = credentials@access_token,
+#'   driver = "ArmadilloDriver")
+#' logindata <- builder$build()
+#'
+#' conns <- datashield.login(logins = logindata, assign = FALSE)
+#' }
 #' @export
 armadillo.get_credentials <- function(server) { # nolint
   auth_info <- .get_oauth_info(server)$auth

--- a/R/ArmadilloOAuth.R
+++ b/R/ArmadilloOAuth.R
@@ -10,6 +10,7 @@
 #'
 #' @export
 armadillo.get_token <- function(server) { # nolint
+  lifecycle::deprecate_warn("3.0.0", "armadillo.get_token()", "armadillo.get_credentials()")
   credentials <- armadillo.get_credentials(server)
   return(credentials@id_token)
 }

--- a/man/armadillo.get_credentials.Rd
+++ b/man/armadillo.get_credentials.Rd
@@ -25,3 +25,19 @@ token to the connection and credentials objects in the global environment. For t
 correctly, ensure that there only exists one DataSHIELD connections object in the global
 environment, and that for each datasource there is only object containing their credentials.
 }
+\examples{
+\dontrun{
+example_url <- "https://armadillo.example.org"
+credentials <- armadillo.get_credentials(example_url)
+
+builder <- newDSLoginBuilder()
+builder$append(
+  url = example_url,
+  server = "example_server",
+  token = credentials@access_token,
+  driver = "ArmadilloDriver")
+logindata <- builder$build()
+
+conns <- datashield.login(logins = logindata, assign = FALSE)
+}
+}


### PR DESCRIPTION
## Changes made
Preparing from CRAN release, specifically:
- Deprecated `armadillo.get_token`
- Added example for `armadillo.get_credentials`
- Updated news.rd

## How to test
- Review news.rd 
- Confirm you're happy to deprecate armadillo.get_token