### PR TITLE
fix: tag release after version bump commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,9 @@ jobs:
           if [  $CIRCLE_BRANCH = "master" ] && [ $PREVIOUS != $NEXT  ]; then
             echo "Releasing ${PACKAGE}:${TAG}, pushing to git"
 
+            git commit -a -m 'Increment DESCRIPTION number'
             git tag v${TAG}
             git push --tags origin master
-            git commit -a -m 'Increment DESCRIPTION number'
-            git push origin master
 
             response=$(curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/molgenis/molgenis-r-datashield/releases \


### PR DESCRIPTION
## Background
Bug in CI meant that tag was created before committing the version bump to DESCRIPTION. This meant release tags (e.g. v1.2.1) pointed to the commit with the previous version.

## What changed
Reordered the release step so the version bump is committed first, then the tag is applied to that commit. 

How to test
- [ ] Code review
- [ ] TC to review one merged into master.