### PR TITLE
Fix/503 status

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -57,10 +57,10 @@
   } else if (response$status_code == 404) {
     stop("Not found", call. = FALSE)
   } else if (response$status_code == 500) {
-    json_content <- content(response, "text")
+    json_content <- content(response, "text", encoding = "UTF-8")
     stop(paste0("Internal server error: ", json_content), call. = FALSE)
   } else if (response$status_code == 503) {
-    json_content <- content(response, "text")
+    json_content <- content(response, "text", encoding = "UTF-8")
     stop(paste0("Service unavailable: ", json_content), call. = FALSE)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -59,6 +59,9 @@
   } else if (response$status_code == 500) {
     json_content <- content(response, "text")
     stop(paste0("Internal server error: ", json_content), call. = FALSE)
+  } else if (response$status_code == 503) {
+    json_content <- content(response, "text")
+    stop(paste0("Service unavailable: ", json_content), call. = FALSE)
   }
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -105,6 +105,20 @@ test_that(".handle_request_error handles 500", {
   )
 })
 
+test_that(".handle_request_error handles 503", {
+  response     <- list(status_code = 503)
+  httr_content <- mock("Could not connect to the profile's R server.")
+
+  with_mocked_bindings({
+    expect_error(
+      .handle_request_error(response),
+      "Service unavailable: Could not connect to the profile's R server."
+    )
+  },
+  content = httr_content
+  )
+})
+
 test_that(".unlist_character_list handles empty list", {
   expect_equal(.unlist_character_list(list()), character())
 })


### PR DESCRIPTION
## Background
Previously the R package didn't handle 503 errors, because it didn't need to. But now a not-started profile on Armadillo will return a 503, so we want to handle this pleasantly. 

## What's changed
Catch 503 errors and display them along with their message. Note, I also added  `encoding = "UTF-8"` to the 500 error handling to silence the annoying warning `No encoding supplied: defaulting to UTF-8.`. Seemed a bit much to make a PR just for this. 

## How to test
-  First ensure that https://github.com/molgenis/molgenis-service-armadillo/pull/1054 is merged into master
- Then start Armadillo locally, and run the following:

```r
url <- "http://localhost:8080"
credentials <- armadillo.get_credentials(url)

profile = [select something that exists but is not started]

builder <- newDSLoginBuilder()

builder$append(
  url = url,
  server = "server_1",
  token = credentials@access_token,
  driver = "ArmadilloDriver",
  profile = profile)

logindata <- builder$build()

conns <- DSI::datashield.login(logins = logindata, assign = FALSE)
```
Expect message:
`Error: Service unavailable: Could not connect to the profile's R server. The profile may exist but its container is not started or not reachable.`

